### PR TITLE
Introducing a new career track "Platform Engineering Team Lead"

### DIFF
--- a/tech/career-framework/career-tracks/platform-engineering-manager.md
+++ b/tech/career-framework/career-tracks/platform-engineering-manager.md
@@ -1,4 +1,4 @@
-# Platform Team Lead
+# Platform Engineering Manager
 
 ## Responsibilities
 

--- a/tech/career-framework/career-tracks/platform-engineering-team-lead.md
+++ b/tech/career-framework/career-tracks/platform-engineering-team-lead.md
@@ -1,0 +1,3 @@
+# Platform Engineering Team Lead
+
+Leading a smaller team, this role is a combination of [Platform Engineering Manager](platform-engineering-manager.md) (40%) and being a [Engineer](engineer.md) (60%)

--- a/tech/career-framework/career-tracks/platform-engineering-team-lead.md
+++ b/tech/career-framework/career-tracks/platform-engineering-team-lead.md
@@ -1,3 +1,3 @@
 # Platform Engineering Team Lead
 
-Leading a smaller team, this role is a combination of [Platform Engineering Manager](platform-engineering-manager.md) (40%) and being a [Engineer](engineer.md) (60%)
+This track is combining a role of [Platform Engineering Manager](platform-engineering-manager.md) and [Engineer](engineer.md). It's designed for the lead engineer in a smaller team (2-3 other members). The overall workload should be split 50:50 between managing team and being an engineer.

--- a/tech/career-framework/career-tracks/product-engineering-manager.md
+++ b/tech/career-framework/career-tracks/product-engineering-manager.md
@@ -1,4 +1,4 @@
-# Product Team Lead
+# Product Engineering Manager
 
 ## Responsibilities
 

--- a/tech/career-framework/career-tracks/readme.md
+++ b/tech/career-framework/career-tracks/readme.md
@@ -14,8 +14,8 @@ As mentioned in the definition of career [progress](../progress.md), different [
 | [Platform Division Lead](platform-division-lead.md)                      | 5  | 25 | 15 | 25 | 30 |
 | [Product Family Lead](product-family-lead.md)                            | 10 | 25 | 15 | 25 | 25 |
 | [Platform Family Lead](platform-family-lead.md)                          | 5  | 30 | 25 | 20 | 20 |
-| [Product Team Lead](product-team-lead.md)                                | 30 | 10 | 20 | 20 | 20 |
-| [Platform Team Lead](platform-team-lead.md)                              | 20 | 20 | 20 | 20 | 20 |
+| [Product Engineering Manager](product-engineering-manager.md)            | 30 | 10 | 20 | 20 | 20 |
+| [Platform Engineering Manager](platform-engineering-manager.md)          | 20 | 20 | 20 | 20 | 20 |
 | [IT and Security Lead](it-and-security-lead.md)                          | 10 | 25 | 25 | 20 | 20 |
 | [Technical Leader](technical-leader.md)                                  | 5  | 30 | 30 | 15 | 20 |
 | [Agile Coach](agile-coach.md)                                            | 10 | 30 | 10 | 25 | 25 |

--- a/tech/career-framework/career-tracks/readme.md
+++ b/tech/career-framework/career-tracks/readme.md
@@ -16,6 +16,7 @@ As mentioned in the definition of career [progress](../progress.md), different [
 | [Platform Family Lead](platform-family-lead.md)                          | 5  | 30 | 25 | 20 | 20 |
 | [Product Engineering Manager](product-engineering-manager.md)            | 30 | 10 | 20 | 20 | 20 |
 | [Platform Engineering Manager](platform-engineering-manager.md)          | 20 | 20 | 20 | 20 | 20 |
+| [Platform Engineernig Team Lead](platform-engineering-team-lead.md)      | 25 | 25 | 25 | 15 | 10 |
 | [IT and Security Lead](it-and-security-lead.md)                          | 10 | 25 | 25 | 20 | 20 |
 | [Technical Leader](technical-leader.md)                                  | 5  | 30 | 30 | 15 | 20 |
 | [Agile Coach](agile-coach.md)                                            | 10 | 30 | 10 | 25 | 25 |


### PR DESCRIPTION
This PR is solving a situation when we want to hire a team lead into a smaller team in which situation we still expect the person to spend time with IC work (e.g. coding), but at the same time they are responsible for the team delivery and managing and couching the other members of the team.

This will help us to attract the right talent and target our job posting better where having just "Engineering Manager" suggests its more about managing people.

Slack: https://mews.slack.com/archives/GB67ZCXST/p1652731056980979

Next steps
 - Adjust Tech Payroll Sheet