### PR TITLE
Introducing "Data Science Team Lead" role

### DIFF
--- a/tech/career-framework/career-tracks/data-science-team-lead.md
+++ b/tech/career-framework/career-tracks/data-science-team-lead.md
@@ -8,7 +8,6 @@
   - Solutioning team initiatives, driving their delivery in an iterative manner and enuring the technical quality.
   - Overseeing team responsibilities and enuring those are being continuously fulfilled.
   - Driving the collaboration with data engineering and other business units to solve various opportunities using data.
-
 - Management
   - Managing members of the team, defining their goals, responsibilities, providing feedback.
   - Growing, coaching and developing the team members to help them progress in their careers.
@@ -16,7 +15,6 @@
   - Acting as a hiring manager, recruiting members of the team.
   - Managing financial planning, spending and selection of service providers for the area.
   - Being the main point of contact representing the IT and security team in cross-organizational matters.
- 
 - Culture
   - Contributing to culture of technical excellence and continuous improvement.
   - Driving agile culture within the team, raising problems in timely manner.

--- a/tech/career-framework/career-tracks/data-science-team-lead.md
+++ b/tech/career-framework/career-tracks/data-science-team-lead.md
@@ -2,6 +2,13 @@
 
 ## Responsibilities
 
+- Delivery & Technology
+  - Designing and owning internal data projects.
+  - Understanding the high-level picture of the organization structure, business and product strategy.
+  - Solutioning team initiatives, driving their delivery in an iterative manner and enuring the technical quality.
+  - Overseeing team responsibilities and enuring those are being continuously fulfilled.
+  - Driving the collaboration with data engineering and other business units to solve various opportunities using data.
+
 - Management
   - Managing members of the team, defining their goals, responsibilities, providing feedback.
   - Growing, coaching and developing the team members to help them progress in their careers.
@@ -9,11 +16,7 @@
   - Acting as a hiring manager, recruiting members of the team.
   - Managing financial planning, spending and selection of service providers for the area.
   - Being the main point of contact representing the IT and security team in cross-organizational matters.
-- Technology
-  - Understanding the high-level picture of the organization structure, platform strategy, usage, products built on top of it.
-  - Solutioning team initiatives, driving their delivery in an iterative manner and enuring the technical quality.
-  - Overseeing team responsibilities and enuring those are being continuously fulfilled.
-  - Designing and owning internal data projects.
+ 
 - Culture
   - Contributing to culture of technical excellence and continuous improvement.
   - Driving agile culture within the team, raising problems in timely manner.

--- a/tech/career-framework/career-tracks/data-science-team-lead.md
+++ b/tech/career-framework/career-tracks/data-science-team-lead.md
@@ -1,0 +1,20 @@
+# Data Science Team Lead
+
+## Responsibilities
+
+- Management
+  - Managing members of the team, defining their goals, responsibilities, providing feedback.
+  - Growing, coaching and developing the team members to help them progress in their careers.
+  - Driving engagement and productivity of the team.
+  - Acting as a hiring manager, recruiting members of the team.
+  - Managing financial planning, spending and selection of service providers for the area.
+  - Being the main point of contact representing the IT and security team in cross-organizational matters.
+- Technology
+  - Understanding the high-level picture of the organization structure, platform strategy, usage, products built on top of it.
+  - Solutioning team initiatives, driving their delivery in an iterative manner and enuring the technical quality.
+  - Overseeing team responsibilities and enuring those are being continuously fulfilled.
+  - Designing and owning internal data projects.
+- Culture
+  - Contributing to culture of technical excellence and continuous improvement.
+  - Driving agile culture within the team, raising problems in timely manner.
+  - Being ambassador of the team, both internally by knowledge sharing and externally by publishing, talking etc.

--- a/tech/career-framework/career-tracks/readme.md
+++ b/tech/career-framework/career-tracks/readme.md
@@ -16,6 +16,7 @@ As mentioned in the definition of career [progress](../progress.md), different [
 | [Platform Family Lead](platform-family-lead.md)                          | 5  | 30 | 25 | 20 | 20 |
 | [Product Team Lead](product-team-lead.md)                                | 30 | 10 | 20 | 20 | 20 |
 | [Platform Team Lead](platform-team-lead.md)                              | 20 | 20 | 20 | 20 | 20 |
+| [Data Science Team Lead](data science-team-lead.md)                      | 25 | 25 | 25 | 15 | 10 |
 | [IT and Security Lead](it-and-security-lead.md)                          | 10 | 25 | 25 | 20 | 20 |
 | [Technical Leader](technical-leader.md)                                  | 5  | 30 | 30 | 15 | 20 |
 | [Agile Coach](agile-coach.md)                                            | 10 | 30 | 10 | 25 | 25 |

--- a/tech/career-framework/career-tracks/readme.md
+++ b/tech/career-framework/career-tracks/readme.md
@@ -16,7 +16,7 @@ As mentioned in the definition of career [progress](../progress.md), different [
 | [Platform Family Lead](platform-family-lead.md)                          | 5  | 30 | 25 | 20 | 20 |
 | [Product Team Lead](product-team-lead.md)                                | 30 | 10 | 20 | 20 | 20 |
 | [Platform Team Lead](platform-team-lead.md)                              | 20 | 20 | 20 | 20 | 20 |
-| [Data Science Team Lead](data science-team-lead.md)                      | 25 | 25 | 25 | 15 | 10 |
+| [Data Science Team Lead](data-science-team-lead.md)                      | 25 | 25 | 25 | 15 | 10 |
 | [IT and Security Lead](it-and-security-lead.md)                          | 10 | 25 | 25 | 20 | 20 |
 | [Technical Leader](technical-leader.md)                                  | 5  | 30 | 30 | 15 | 20 |
 | [Agile Coach](agile-coach.md)                                            | 10 | 30 | 10 | 25 | 25 |

--- a/tech/career-framework/grades.md
+++ b/tech/career-framework/grades.md
@@ -32,6 +32,10 @@ For example an engineer with progress P = 2.50 would have grade IC4, minimum nor
 | Platform Team Lead         | 1.40  | 2.60  | S2    | Engineering Manager                             |      92000 |      121000 |
 | Platform Team Lead         | 2.60  | 3.80  | M1    | Engineering Manager                             |     121000 |      161000 |
 | Platform Team Lead         | 3.80  | 5.00  | M2    | Senior Engineering Manager                      |     161000 |      207000 |
+| Data Science Team Lead     | 0.00  | 1.40  | S1    | Team Lead, Data Science                         |      69000 |       92000 |
+| Data Science Team Lead     | 1.40  | 2.60  | S2    | Team Lead, Data Science                         |      92000 |      121000 |
+| Data Science Team Lead     | 2.60  | 3.80  | M1    | Team Lead, Data Science                         |     121000 |      161000 |
+| Data Science Team Lead     | 3.80  | 5.00  | M2    | Senior Team Lead, Data Science                  |     161000 |      207000 |
 | IT and Security Lead       | 0.00  | 1.40  | S1    | IT and Security Manager                         |      81000 |      115000 |
 | IT and Security Lead       | 1.40  | 2.60  | S2    | IT and Security Manager                         |     115000 |      150000 |
 | IT and Security Lead       | 2.60  | 3.80  | M1    | IT and Security Manager                         |     150000 |      184000 |


### PR DESCRIPTION
This PR is solving a situation when we want to hire a team lead into a smaller team in which situation we still expect the person to spend time with IC work (e.g. coding), but at the same time they are responsible for the team delivery and managing and couching the other members of the team.

This will help us to attract the right talent and target our job posting better where having just "Engineering Manager" suggests its more about managing people.

Slack: https://mews.slack.com/archives/GB67ZCXST/p1652731056980979

Next steps
 - Adjust Tech Payroll Sheet