### PR TITLE
Proposal of new unique job titles

### DIFF
--- a/tech/career-framework/grades.md
+++ b/tech/career-framework/grades.md
@@ -32,7 +32,7 @@ For example an engineer with progress P = 2.50 would have grade IC4, minimum nor
 | Platform Team Lead         | 3.80  | 5.00  | M2    | Senior Engineering Manager II                   |     161000 |      207000 |
 | Product Security Team Lead | 0.00  | 1.40  | S1    | Product Security Team Lead                      |      69000 |       92000 |
 | Product Security Team Lead | 1.40  | 2.60  | S2    | Product Security Team Lead II                   |      92000 |      121000 |
-| Product Security Team Lead | 2.60  | 3.80  | M1    | Snior Product Security Team Lead                |     121000 |      161000 |
+| Product Security Team Lead | 2.60  | 3.80  | M1    | Senior Product Security Team Lead               |     121000 |      161000 |
 | Product Security Team Lead | 3.80  | 5.00  | M2    | Senior Product Security Team Lead II            |     161000 |      207000 |
 | Data Science Team Lead     | 0.00  | 1.40  | S1    | Team Lead, Data Science                         |      69000 |       92000 |
 | Data Science Team Lead     | 1.40  | 2.60  | S2    | Team Lead II, Data Science                      |      92000 |      121000 |

--- a/tech/career-framework/grades.md
+++ b/tech/career-framework/grades.md
@@ -23,69 +23,69 @@ For example an engineer with progress P = 2.50 would have grade IC4, minimum nor
 | Platform Family Lead       | 3.10  | 4.20  | D1    | Director of Engineering, {Discriminator}        |     175000 |      210000 |
 | Platform Family Lead       | 4.20  | 5.00  | D2    | Senior Director of Engineering, {Discriminator} |     210000 |      250000 |
 | Product Team Lead          | 0.00  | 1.40  | S1    | Engineering Manager                             |      69000 |       92000 |
-| Product Team Lead          | 1.40  | 2.60  | S2    | Engineering Manager                             |      92000 |      121000 |
-| Product Team Lead          | 2.60  | 3.80  | M1    | Engineering Manager                             |     121000 |      161000 |
-| Product Team Lead          | 3.80  | 5.00  | M2    | Senior Engineering Manager                      |     161000 |      207000 |
+| Product Team Lead          | 1.40  | 2.60  | S2    | Engineering Manager II                          |      92000 |      121000 |
+| Product Team Lead          | 2.60  | 3.80  | M1    | Senior Engineering Manager                      |     121000 |      161000 |
+| Product Team Lead          | 3.80  | 5.00  | M2    | Senior Engineering Manager II                   |     161000 |      207000 |
 | Platform Team Lead         | 0.00  | 1.40  | S1    | Engineering Manager                             |      69000 |       92000 |
-| Platform Team Lead         | 1.40  | 2.60  | S2    | Engineering Manager                             |      92000 |      121000 |
-| Platform Team Lead         | 2.60  | 3.80  | M1    | Engineering Manager                             |     121000 |      161000 |
-| Platform Team Lead         | 3.80  | 5.00  | M2    | Senior Engineering Manager                      |     161000 |      207000 |
+| Platform Team Lead         | 1.40  | 2.60  | S2    | Engineering Manager II                          |      92000 |      121000 |
+| Platform Team Lead         | 2.60  | 3.80  | M1    | Senior Engineering Manager                      |     121000 |      161000 |
+| Platform Team Lead         | 3.80  | 5.00  | M2    | Senior Engineering Manager II                   |     161000 |      207000 |
 | Product Security Team Lead | 0.00  | 1.40  | S1    | Product Security Team Lead                      |      69000 |       92000 |
-| Product Security Team Lead | 1.40  | 2.60  | S2    | Product Security Team Lead                      |      92000 |      121000 |
-| Product Security Team Lead | 2.60  | 3.80  | M1    | Product Security Team Lead                      |     121000 |      161000 |
-| Product Security Team Lead | 3.80  | 5.00  | M2    | Senior Product Security Team Lead               |     161000 |      207000 |
+| Product Security Team Lead | 1.40  | 2.60  | S2    | Product Security Team Lead II                   |      92000 |      121000 |
+| Product Security Team Lead | 2.60  | 3.80  | M1    | Snior Product Security Team Lead                |     121000 |      161000 |
+| Product Security Team Lead | 3.80  | 5.00  | M2    | Senior Product Security Team Lead II            |     161000 |      207000 |
 | Data Science Team Lead     | 0.00  | 1.40  | S1    | Team Lead, Data Science                         |      69000 |       92000 |
-| Data Science Team Lead     | 1.40  | 2.60  | S2    | Team Lead, Data Science                         |      92000 |      121000 |
-| Data Science Team Lead     | 2.60  | 3.80  | M1    | Team Lead, Data Science                         |     121000 |      161000 |
-| Data Science Team Lead     | 3.80  | 5.00  | M2    | Senior Team Lead, Data Science                  |     161000 |      207000 |
+| Data Science Team Lead     | 1.40  | 2.60  | S2    | Team Lead II, Data Science                      |      92000 |      121000 |
+| Data Science Team Lead     | 2.60  | 3.80  | M1    | Senior Team Lead, Data Science                  |     121000 |      161000 |
+| Data Science Team Lead     | 3.80  | 5.00  | M2    | Senior Team Lead II, Data Science               |     161000 |      207000 |
 | IT and Security Lead       | 0.00  | 1.40  | S1    | IT and Security Manager                         |      81000 |      115000 |
-| IT and Security Lead       | 1.40  | 2.60  | S2    | IT and Security Manager                         |     115000 |      150000 |
-| IT and Security Lead       | 2.60  | 3.80  | M1    | IT and Security Manager                         |     150000 |      184000 |
-| IT and Security Lead       | 3.80  | 5.00  | M2    | Senior IT and Security Manager                  |     184000 |      230000 |
+| IT and Security Lead       | 1.40  | 2.60  | S2    | IT and Security Manager II                      |     115000 |      150000 |
+| IT and Security Lead       | 2.60  | 3.80  | M1    | Senior IT and Security Manager                  |     150000 |      184000 |
+| IT and Security Lead       | 3.80  | 5.00  | M2    | Senior IT and Security Manager II               |     184000 |      230000 |
 | Technical Leader           | 0.00  | 3.10  | S2    | Staff {Discriminator} Engineer                  |     115000 |      150000 |
 | Technical Leader           | 3.10  | 4.20  | M1    | Senior Staff {Discriminator} Engineer           |     150000 |      184000 |
 | Technical Leader           | 4.20  | 5.00  | D1    | Principal {Discriminator} Engineer              |     184000 |      230000 |
 | Agile Coach                | 0.00  | 1.40  | IC2   | Agile Coach                                     |      69000 |       92000 |
-| Agile Coach                | 1.40  | 2.60  | IC3   | Agile Coach                                     |      92000 |      121000 |
+| Agile Coach                | 1.40  | 2.60  | IC3   | Agile Coach II                                  |      92000 |      121000 |
 | Agile Coach                | 2.60  | 3.80  | IC4   | Senior Agile Coach                              |     121000 |      161000 |
-| Agile Coach                | 3.80  | 5.00  | IC5   | Staff Agile Coach                               |     161000 |      207000 |
+| Agile Coach                | 3.80  | 5.00  | IC5   | Senior Agile Coach II                           |     161000 |      207000 |
 | Community Manager          | 0.00  | 1.40  | S1    | Community Manager                               |      46000 |       69000 |
-| Community Manager          | 1.40  | 2.60  | S2    | Community Manager                               |      69000 |       98000 |
-| Community Manager          | 2.60  | 3.80  | M1    | Community Manager                               |      98000 |      138000 |
-| Community Manager          | 3.80  | 5.00  | M2    | Senior Community Manager                        |     138000 |      184000 |
+| Community Manager          | 1.40  | 2.60  | S2    | Community Manager II                            |      69000 |       98000 |
+| Community Manager          | 2.60  | 3.80  | M1    | Senior Community Manager                        |      98000 |      138000 |
+| Community Manager          | 3.80  | 5.00  | M2    | Senior Community Manager II                     |     138000 |      184000 |
 | Engineer                   | 0.00  | 1.20  | IC2   | {Discriminator} Engineer                        |      46000 |       69000 |
-| Engineer                   | 1.20  | 2.40  | IC3   | {Discriminator} Engineer                        |      69000 |       98000 |
+| Engineer                   | 1.20  | 2.40  | IC3   | {Discriminator} Engineer II                     |      69000 |       98000 |
 | Engineer                   | 2.40  | 3.60  | IC4   | Senior {Discriminator} Engineer                 |      98000 |      138000 |
-| Engineer                   | 3.60  | 5.00  | IC5   | Staff {Discriminator} Engineer                  |     138000 |      184000 |
+| Engineer                   | 3.60  | 5.00  | IC5   | Senior {Discriminator} Engineer II              |     138000 |      184000 |
 | Product Security Engineer  | 0.00  | 1.20  | IC2   | Product Security Engineer                       |      46000 |       69000 |
-| Product Security Engineer  | 1.20  | 2.40  | IC3   | Product Security Engineer                       |      69000 |       98000 |
+| Product Security Engineer  | 1.20  | 2.40  | IC3   | Product Security Engineer II                    |      69000 |       98000 |
 | Product Security Engineer  | 2.40  | 3.60  | IC4   | Senior Product Security Engineer                |      98000 |      138000 |
-| Product Security Engineer  | 3.60  | 5.00  | IC5   | Staff Product Security Engineer                 |     138000 |      184000 |
+| Product Security Engineer  | 3.60  | 5.00  | IC5   | Senior Product Security Engineer II             |     138000 |      184000 |
 | Data Scientist             | 0.00  | 1.20  | IC2   | Data Scientist                                  |      46000 |       69000 |
-| Data Scientist             | 1.20  | 2.40  | IC3   | Data Scientist                                  |      69000 |       98000 |
+| Data Scientist             | 1.20  | 2.40  | IC3   | Data Scientist II                               |      69000 |       98000 |
 | Data Scientist             | 2.40  | 3.60  | IC4   | Senior Data Scientist                           |      98000 |      138000 |
-| Data Scientist             | 3.60  | 5.00  | IC5   | Staff Data Scientist                            |     138000 |      184000 |
+| Data Scientist             | 3.60  | 5.00  | IC5   | Senior Data Scientist II                        |     138000 |      184000 |
 | IT Security Engineer       | 0.00  | 1.20  | IC2   | IT Security Engineer                            |      46000 |       69000 |
-| IT Security Engineer       | 1.20  | 2.40  | IC3   | IT Security Engineer                            |      69000 |       98000 |
+| IT Security Engineer       | 1.20  | 2.40  | IC3   | IT Security Engineer II                         |      69000 |       98000 |
 | IT Security Engineer       | 2.40  | 3.60  | IC4   | Senior IT Security Engineer                     |      98000 |      138000 |
-| IT Security Engineer       | 3.60  | 5.00  | IC5   | Staff IT Security Engineer                      |     138000 |      184000 |
+| IT Security Engineer       | 3.60  | 5.00  | IC5   | Senior IT Security Engineer II                  |     138000 |      184000 |
 | Data Analyst               | 0.00  | 1.20  | IC2   | Data Analyst                                    |      40000 |       63000 |
-| Data Analyst               | 1.20  | 2.40  | IC3   | Data Analyst                                    |      63000 |       92000 |
+| Data Analyst               | 1.20  | 2.40  | IC3   | Data Analyst II                                 |      63000 |       92000 |
 | Data Analyst               | 2.40  | 3.60  | IC4   | Senior Data Analyst                             |      92000 |      127000 |
-| Data Analyst               | 3.60  | 5.00  | IC5   | Staff Data Analyst                              |     127000 |      161000 |
+| Data Analyst               | 3.60  | 5.00  | IC5   | Senior Data Analyst II                          |     127000 |      161000 |
 | IT Infrastructure Engineer | 0.00  | 1.20  | IC2   | IT Infrastructure Engineer                      |      40000 |       63000 |
-| IT Infrastructure Engineer | 1.20  | 2.40  | IC3   | IT Infrastructure Engineer                      |      63000 |       92000 |
+| IT Infrastructure Engineer | 1.20  | 2.40  | IC3   | IT Infrastructure Engineer II                   |      63000 |       92000 |
 | IT Infrastructure Engineer | 2.40  | 3.60  | IC4   | Senior IT Infrastructure Engineer               |      92000 |      127000 |
-| IT Infrastructure Engineer | 3.60  | 5.00  | IC5   | Staff IT Infrastructure Engineer                |     127000 |      161000 |
+| IT Infrastructure Engineer | 3.60  | 5.00  | IC5   | Senior IT Infrastructure Engineer II            |     127000 |      161000 |
 | QA Engineer                | 0.00  | 1.20  | IC1   | QA Engineer                                     |      35000 |       46000 |
-| QA Engineer                | 1.20  | 2.40  | IC2   | QA Engineer                                     |      46000 |       63000 |
+| QA Engineer                | 1.20  | 2.40  | IC2   | QA Engineer II                                  |      46000 |       63000 |
 | QA Engineer                | 2.40  | 3.60  | IC3   | Senior QA Engineer                              |      63000 |       92000 |
-| QA Engineer                | 3.60  | 5.00  | IC4   | Staff QA Engineer                               |      92000 |      127000 |
+| QA Engineer                | 3.60  | 5.00  | IC4   | Senior QA Engineer II                           |      92000 |      127000 |
 | IT Specialist              | 0.00  | 1.20  | IC1   | IT Specialist                                   |      35000 |       46000 |
-| IT Specialist              | 1.20  | 2.40  | IC2   | IT Specialist                                   |      46000 |       63000 |
-| IT Specialist              | 2.40  | 3.60  | IC3   | IT Specialist                                   |      63000 |       92000 |
-| IT Specialist              | 3.60  | 5.00  | IC4   | Senior IT Specialist                            |      92000 |      127000 |
+| IT Specialist              | 1.20  | 2.40  | IC2   | IT Specialist II                                |      46000 |       63000 |
+| IT Specialist              | 2.40  | 3.60  | IC3   | Senior IT Specialist                            |      63000 |       92000 |
+| IT Specialist              | 3.60  | 5.00  | IC4   | Senior IT Specialist II                         |      92000 |      127000 |
 | Community Coordinator      | 0.00  | 1.20  | IC1   | Community Coordinator                           |      35000 |       46000 |
-| Community Coordinator      | 1.20  | 2.40  | IC2   | Community Coordinator                           |      46000 |       63000 |
-| Community Coordinator      | 2.40  | 3.60  | IC3   | Community Coordinator                           |      63000 |       92000 |
-| Community Coordinator      | 3.60  | 5.00  | IC4   | Senior Community Coordinator                    |      92000 |      127000 |
+| Community Coordinator      | 1.20  | 2.40  | IC2   | Community Coordinator II                        |      46000 |       63000 |
+| Community Coordinator      | 2.40  | 3.60  | IC3   | Senior Community Coordinator                    |      63000 |       92000 |
+| Community Coordinator      | 3.60  | 5.00  | IC4   | Senior Community Coordinator II                 |      92000 |      127000 |

--- a/tech/career-framework/grades.md
+++ b/tech/career-framework/grades.md
@@ -23,25 +23,25 @@ For example an engineer with progress P = 2.50 would have grade IC4, minimum nor
 | Platform Family Lead       | 3.10  | 4.20  | D1    | Director of Engineering, {Discriminator}        |     175000 |      210000 |
 | Platform Family Lead       | 4.20  | 5.00  | D2    | Senior Director of Engineering, {Discriminator} |     210000 |      250000 |
 | Product Team Lead          | 0.00  | 1.40  | S1    | Engineering Manager                             |      69000 |       92000 |
-| Product Team Lead          | 1.40  | 2.60  | S2    | Engineering Manager II                          |      92000 |      121000 |
-| Product Team Lead          | 2.60  | 3.80  | M1    | Senior Engineering Manager                      |     121000 |      161000 |
-| Product Team Lead          | 3.80  | 5.00  | M2    | Senior Engineering Manager II                   |     161000 |      207000 |
+| Product Team Lead          | 1.40  | 2.60  | S2    | Engineering Manager                             |      92000 |      121000 |
+| Product Team Lead          | 2.60  | 3.80  | M1    | Engineering Manager                             |     121000 |      161000 |
+| Product Team Lead          | 3.80  | 5.00  | M2    | Senior Engineering Manager                      |     161000 |      207000 |
 | Platform Team Lead         | 0.00  | 1.40  | S1    | Engineering Manager                             |      69000 |       92000 |
-| Platform Team Lead         | 1.40  | 2.60  | S2    | Engineering Manager II                          |      92000 |      121000 |
-| Platform Team Lead         | 2.60  | 3.80  | M1    | Senior Engineering Manager                      |     121000 |      161000 |
-| Platform Team Lead         | 3.80  | 5.00  | M2    | Senior Engineering Manager II                   |     161000 |      207000 |
+| Platform Team Lead         | 1.40  | 2.60  | S2    | Engineering Manager                             |      92000 |      121000 |
+| Platform Team Lead         | 2.60  | 3.80  | M1    | Engineering Manager                             |     121000 |      161000 |
+| Platform Team Lead         | 3.80  | 5.00  | M2    | Senior Engineering Manager                      |     161000 |      207000 |
 | Product Security Team Lead | 0.00  | 1.40  | S1    | Product Security Team Lead                      |      69000 |       92000 |
-| Product Security Team Lead | 1.40  | 2.60  | S2    | Product Security Team Lead II                   |      92000 |      121000 |
-| Product Security Team Lead | 2.60  | 3.80  | M1    | Senior Product Security Team Lead               |     121000 |      161000 |
-| Product Security Team Lead | 3.80  | 5.00  | M2    | Senior Product Security Team Lead II            |     161000 |      207000 |
+| Product Security Team Lead | 1.40  | 2.60  | S2    | Product Security Team Lead                      |      92000 |      121000 |
+| Product Security Team Lead | 2.60  | 3.80  | M1    | Product Security Team Lead                      |     121000 |      161000 |
+| Product Security Team Lead | 3.80  | 5.00  | M2    | Senior Product Security Team Lead               |     161000 |      207000 |
 | Data Science Team Lead     | 0.00  | 1.40  | S1    | Team Lead, Data Science                         |      69000 |       92000 |
-| Data Science Team Lead     | 1.40  | 2.60  | S2    | Team Lead II, Data Science                      |      92000 |      121000 |
-| Data Science Team Lead     | 2.60  | 3.80  | M1    | Senior Team Lead, Data Science                  |     121000 |      161000 |
-| Data Science Team Lead     | 3.80  | 5.00  | M2    | Senior Team Lead II, Data Science               |     161000 |      207000 |
+| Data Science Team Lead     | 1.40  | 2.60  | S2    | Team Lead, Data Science                         |      92000 |      121000 |
+| Data Science Team Lead     | 2.60  | 3.80  | M1    | Team Lead, Data Science                         |     121000 |      161000 |
+| Data Science Team Lead     | 3.80  | 5.00  | M2    | Senior Team Lead, Data Science                  |     161000 |      207000 |
 | IT and Security Lead       | 0.00  | 1.40  | S1    | IT and Security Manager                         |      81000 |      115000 |
-| IT and Security Lead       | 1.40  | 2.60  | S2    | IT and Security Manager II                      |     115000 |      150000 |
-| IT and Security Lead       | 2.60  | 3.80  | M1    | Senior IT and Security Manager                  |     150000 |      184000 |
-| IT and Security Lead       | 3.80  | 5.00  | M2    | Senior IT and Security Manager II               |     184000 |      230000 |
+| IT and Security Lead       | 1.40  | 2.60  | S2    | IT and Security Manager                         |     115000 |      150000 |
+| IT and Security Lead       | 2.60  | 3.80  | M1    | IT and Security Manager                         |     150000 |      184000 |
+| IT and Security Lead       | 3.80  | 5.00  | M2    | Senior IT and Security Manager                  |     184000 |      230000 |
 | Technical Leader           | 0.00  | 3.10  | S2    | Staff {Discriminator} Engineer                  |     115000 |      150000 |
 | Technical Leader           | 3.10  | 4.20  | M1    | Senior Staff {Discriminator} Engineer           |     150000 |      184000 |
 | Technical Leader           | 4.20  | 5.00  | D1    | Principal {Discriminator} Engineer              |     184000 |      230000 |
@@ -50,9 +50,9 @@ For example an engineer with progress P = 2.50 would have grade IC4, minimum nor
 | Agile Coach                | 2.60  | 3.80  | IC4   | Senior Agile Coach                              |     121000 |      161000 |
 | Agile Coach                | 3.80  | 5.00  | IC5   | Senior Agile Coach II                           |     161000 |      207000 |
 | Community Manager          | 0.00  | 1.40  | S1    | Community Manager                               |      46000 |       69000 |
-| Community Manager          | 1.40  | 2.60  | S2    | Community Manager II                            |      69000 |       98000 |
-| Community Manager          | 2.60  | 3.80  | M1    | Senior Community Manager                        |      98000 |      138000 |
-| Community Manager          | 3.80  | 5.00  | M2    | Senior Community Manager II                     |     138000 |      184000 |
+| Community Manager          | 1.40  | 2.60  | S2    | Community Manager                               |      69000 |       98000 |
+| Community Manager          | 2.60  | 3.80  | M1    | Community Manager                               |      98000 |      138000 |
+| Community Manager          | 3.80  | 5.00  | M2    | Senior Community Manager                        |     138000 |      184000 |
 | Engineer                   | 0.00  | 1.20  | IC2   | {Discriminator} Engineer                        |      46000 |       69000 |
 | Engineer                   | 1.20  | 2.40  | IC3   | {Discriminator} Engineer II                     |      69000 |       98000 |
 | Engineer                   | 2.40  | 3.60  | IC4   | Senior {Discriminator} Engineer                 |      98000 |      138000 |


### PR DESCRIPTION
Aim of this proposal is to fix a few things for IC career tracks:

- Ambiguity of current "Staff Engineer" job title which is used on two career tracks (engineer, technical leader). This is causing quite lot of confusion.
- We have different rules for usage of "Senior" in our career tracks. For some tracks with 4 grades, it is used on the highest grade only (e.g. Community coordinator). On other tracks it is used on 3rd grade and the highest grade uses "Staff". By unifying this, all standard career tracks with 4 grades would use the following format:
  - {Title}
  - {Title} II
  - Senior {Title}
  - Senior {Title} II
- Right now, we have no unique identifier of person's career track and progress. It's a combination of their career track and grade. With this, job title will start serving this purpose.
- As a consequence of previous point, this levels the playing field in terms of openness. For some tracks, the job title already determines person's grade openly (e.g. technical leader). For other tracks, it doesn't and e.g. "Engineering manager" can mean multiple different things. After this change, job title will determine grade for everyone, so overall, it increases openness of the framework.